### PR TITLE
Fix: normal iron hoes were being identified as cloning tool (Issue #568)

### DIFF
--- a/src/main/java/org/mineacademy/corearena/tool/CloneSpawnerToolOff.java
+++ b/src/main/java/org/mineacademy/corearena/tool/CloneSpawnerToolOff.java
@@ -71,11 +71,6 @@ public final class CloneSpawnerToolOff extends Tool {
 	}
 
 	@Override
-	public boolean compareByNbt() {
-		return true;
-	}
-
-	@Override
 	public void onHotbarFocused(Player player) {
 	}
 

--- a/src/main/java/org/mineacademy/corearena/tool/CloneSpawnerToolOn.java
+++ b/src/main/java/org/mineacademy/corearena/tool/CloneSpawnerToolOn.java
@@ -148,11 +148,6 @@ public final class CloneSpawnerToolOn extends Tool {
 	}
 
 	@Override
-	public boolean compareByNbt() {
-		return true;
-	}
-
-	@Override
 	public boolean ignoreCancelled() {
 		return false;
 	}


### PR DESCRIPTION
(Issue #568)

The changed tools had overrided `compareByNbt` method to return true, and this was causing the comparing of the items to rely only on the items NBT tags. If the tool itself has no NBT tags, it would match with a normal tool of the same type.

Tool functionality was tested and everything still works.